### PR TITLE
Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.rs]
+indent_size = 4
+indent_style = space
+
+[*.toml]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
EditorConfig is a simple convention to configure the behavior of code
editors. A default configuration has been added to the template
repository.